### PR TITLE
Remove mimemagic gem dependency to avoid GPL licensing issue

### DIFF
--- a/lib/paperclip.rb
+++ b/lib/paperclip.rb
@@ -64,8 +64,6 @@ rescue LoadError
   require "mime/types"
 end
 
-require 'mimemagic'
-require 'mimemagic/overlay'
 require 'logger'
 require 'cocaine'
 

--- a/lib/paperclip/content_type_detector.rb
+++ b/lib/paperclip/content_type_detector.rb
@@ -60,16 +60,10 @@ module Paperclip
     end
 
     def type_from_file_contents
-      type_from_mime_magic || type_from_file_command
+      type_from_file_command
     rescue Errno::ENOENT => e
       Paperclip.log("Error while determining content type: #{e}")
       SENSIBLE_DEFAULT
-    end
-
-    def type_from_mime_magic
-      @type_from_mime_magic ||= File.open(@filepath) do |file|
-        MimeMagic.by_magic(file).try(:type)
-      end
     end
 
     def type_from_file_command

--- a/paperclip.gemspec
+++ b/paperclip.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |s|
   s.add_dependency('activesupport', '>= 4.2.0')
   s.add_dependency('cocaine', '~> 0.5.5')
   s.add_dependency('mime-types')
-  s.add_dependency('mimemagic', '~> 0.3.0')
 
   s.add_development_dependency('activerecord', '>= 4.2.0')
   s.add_development_dependency('shoulda')


### PR DESCRIPTION
All versions of mimemagic were pulled from rubygems due to a
GPL licensing issue. We can't depend on the gem any longer.

See https://github.com/minad/mimemagic/issues/98 for details.